### PR TITLE
check the proof by Tx height

### DIFF
--- a/erc20-connector/contracts/Locker.sol
+++ b/erc20-connector/contracts/Locker.sol
@@ -33,13 +33,17 @@ contract Locker {
         internal
         returns (ProofDecoder.ExecutionStatus memory result)
     {
-        require(proofBlockHeight >= minBlockAcceptanceHeight_, "Proof is from the ancient block");
         require(prover_.proveOutcome(proofData, proofBlockHeight), "Proof should be valid");
 
         // Unpack the proof and extract the execution outcome.
         Borsh.Data memory borshData = Borsh.from(proofData);
         ProofDecoder.FullOutcomeProof memory fullOutcomeProof = borshData.decodeFullOutcomeProof();
         require(borshData.finished(), "Argument should be exact borsh serialization");
+        require(
+            fullOutcomeProof.block_header_lite.inner_lite.height >=
+                minBlockAcceptanceHeight_,
+            "Proof is from the ancient block"
+        );
 
         bytes32 receiptId = fullOutcomeProof.outcome_proof.outcome_with_id.outcome.receipt_ids[0];
         require(!usedProofs_[receiptId], "The burn event proof cannot be reused");

--- a/erc20-connector/test/TokenLocker.js
+++ b/erc20-connector/test/TokenLocker.js
@@ -208,6 +208,23 @@ contract('TokenLocker', function ([adminAddress, addr1, addr2]) {
         });
     });
 
+    it.only('can not unlock, proof is invalid', async function () {
+        let proof = require('./proof_template.json');
+        proof.outcome_proof.outcome.status.SuccessValue = serialize(SCHEMA, 'Unlock', {
+            flag: 0,
+            amount: toWei('1'),
+            token: hexToBytes(token.address),
+            recipient: hexToBytes(addr1),
+        }).toString('base64');
+        const lockerBalance = await token.balanceOf(locker.address);
+        const receiverBalance = await token.balanceOf(addr1);
+
+        await expectRevert(
+            locker.unlockToken(borshifyOutcomeProof(proof), 1099),
+            "Proof is from the ancient block"
+            )
+    });
+
     /*it('deposit & withdraw', async function() {
         assert(await locker.isBridgeToken(btoken.address));
         expect(await locker.ethToNearToken(btoken.address)).equal(nearToken);


### PR DESCRIPTION
- Check if the proof is not from an ancient block. The check is done using by comparing the Tx finality height and the minBlockAcceptanceHeight.

Fixes #56 