### PR TITLE
Metadata connector: fix incorrect log output

### DIFF
--- a/metadata-connector/contracts/ERC20MetadataLogger.sol
+++ b/metadata-connector/contracts/ERC20MetadataLogger.sol
@@ -15,7 +15,7 @@ contract ERC20MetadataLogger {
             string name,
             string symbol,
             uint8 decimals,
-            uint256 timestamp
+            uint256 block_height
         );
 
     /**


### PR DESCRIPTION
* Metadata connector log: use `Log.block_height` instead of `Log.timestamp` as it was a wrong variable name

Fixes #86 
 