### PR TITLE
FT connector:  add prefix to results

### DIFF
--- a/bridge-common/Cargo.toml
+++ b/bridge-common/Cargo.toml
@@ -15,3 +15,7 @@ tiny-keccak = "1.4.0"
 rlp = "0.4.2"
 serde = { version = "1.0", features = ["derive"] }
 hex = "0.4.2"
+
+[features]
+default = ["result_with_prefix"]
+result_with_prefix = []

--- a/bridge-common/src/lib.rs
+++ b/bridge-common/src/lib.rs
@@ -1,31 +1,7 @@
-use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::{Balance, AccountId, BlockHeight};
-use prover::EthAddress;
+use near_sdk::AccountId;
 
 pub mod prover;
-
-
-
-#[derive(Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize)]
-pub enum ResultType {
-    Withdraw {
-        amount: Balance,
-        token: EthAddress,
-        recipient: EthAddress,
-    },
-    Lock {
-        token: String,
-        amount: Balance,
-        recipient: EthAddress,
-    },
-    Metadata {
-        token: String,
-        name: String,
-        symbol: String,
-        decimals: u8,
-        block_height: BlockHeight,
-    }
-}
+pub mod result_types;
 
 pub struct Recipient {
     pub target: AccountId,
@@ -59,7 +35,7 @@ pub fn parse_recipient(recipient: String) -> Recipient {
         }
     } else {
         Recipient {
-            target:  recipient.parse().unwrap(),
+            target: recipient.parse().unwrap(),
             message: None,
         }
     }

--- a/bridge-common/src/prover.rs
+++ b/bridge-common/src/prover.rs
@@ -1,13 +1,13 @@
 use std::convert::From;
 
-use admin_controlled::{Mask};
+use admin_controlled::Mask;
 use eth_types::*;
-use ethabi::{Event, EventParam, Hash, Log, ParamType, RawLog, Token};
 use ethabi::param_type::Writer;
+use ethabi::{Event, EventParam, Hash, Log, ParamType, RawLog, Token};
 
-use near_sdk::{env, ext_contract, Gas, Balance};
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
+use near_sdk::{env, ext_contract, Balance, Gas};
 use tiny_keccak::Keccak;
 
 pub type EthAddress = [u8; 20];

--- a/bridge-common/src/result_types.rs
+++ b/bridge-common/src/result_types.rs
@@ -1,0 +1,111 @@
+use crate::prover::EthAddress;
+use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::{Balance, BlockHeight};
+
+pub type ResultPrefix = [u8; 32];
+
+pub const RESULT_PREFIX_WITHDRAW: ResultPrefix = [
+    246, 181, 82, 1, 204, 142, 13, 135, 141, 218, 111, 185, 98, 41, 84, 186, 141, 37, 252, 127, 56,
+    255, 227, 34, 202, 249, 14, 225, 115, 248, 131, 171,
+];
+pub const RESULT_PREFIX_LOCK: ResultPrefix = [
+    10, 158, 184, 119, 69, 133, 121, 219, 206, 131, 234, 87, 213, 86, 190, 80, 209, 195, 22, 11,
+    181, 241, 113, 159, 177, 114, 189, 51, 0, 172, 134, 35,
+];
+pub const RESULT_PREFIX_METADATA: ResultPrefix = [
+    179, 21, 212, 214, 232, 242, 53, 245, 250, 187, 11, 26, 15, 17, 133, 7, 246, 200, 84, 47, 174,
+    142, 26, 149, 102, 171, 230, 7, 98, 4, 124, 22,
+];
+
+#[derive(Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize)]
+pub struct Withdraw {
+    #[cfg(feature = "result_with_prefix")]
+    pub prefix: ResultPrefix,
+    pub amount: Balance,
+    pub token: EthAddress,
+    pub recipient: EthAddress,
+}
+
+impl Default for Withdraw {
+    fn default() -> Self {
+        Self {
+            #[cfg(feature = "result_with_prefix")]
+            prefix: RESULT_PREFIX_WITHDRAW,
+            amount: Default::default(),
+            token: Default::default(),
+            recipient: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize)]
+pub struct Lock {
+    #[cfg(feature = "result_with_prefix")]
+    pub prefix: ResultPrefix,
+    pub token: String,
+    pub amount: Balance,
+    pub recipient: EthAddress,
+}
+
+impl Default for Lock {
+    fn default() -> Self {
+        Self {
+            #[cfg(feature = "result_with_prefix")]
+            prefix: RESULT_PREFIX_LOCK,
+            token: Default::default(),
+            amount: Default::default(),
+            recipient: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize)]
+pub struct Metadata {
+    #[cfg(feature = "result_with_prefix")]
+    pub prefix: ResultPrefix,
+    pub token: String,
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+    pub block_height: BlockHeight,
+}
+
+impl Default for Metadata {
+    fn default() -> Self {
+        Self {
+            #[cfg(feature = "result_with_prefix")]
+            prefix: RESULT_PREFIX_METADATA,
+            token: Default::default(),
+            name: Default::default(),
+            symbol: Default::default(),
+            decimals: Default::default(),
+            block_height: Default::default(),
+        }
+    }
+}
+
+#[test]
+fn generate_result_prefixs() {
+    assert_eq!(
+        RESULT_PREFIX_WITHDRAW,
+        near_sdk::env::keccak256(b"ResultType.Withdraw").as_slice()
+    );
+    assert_eq!(
+        RESULT_PREFIX_LOCK,
+        near_sdk::env::keccak256(b"ResultType.Lock").as_slice()
+    );
+    assert_eq!(
+        RESULT_PREFIX_METADATA,
+        near_sdk::env::keccak256(b"ResultType.Metadata").as_slice()
+    );
+
+    println!(
+        "RESULT_PREFIX_WITHDRAW: {}",
+        hex::encode(RESULT_PREFIX_WITHDRAW)
+    );
+    println!("RESULT_PREFIX_LOCK: {}", hex::encode(RESULT_PREFIX_LOCK));
+    println!(
+        "RESULT_PREFIX_METADATA: {}",
+        hex::encode(RESULT_PREFIX_METADATA)
+    );
+}

--- a/bridge-common/src/result_types.rs
+++ b/bridge-common/src/result_types.rs
@@ -4,14 +4,19 @@ use near_sdk::{Balance, BlockHeight};
 
 pub type ResultPrefix = [u8; 32];
 
+/// This prefix value is computed as: `keccak256(b"ResultType.Withdraw").as_slice()`
 pub const RESULT_PREFIX_WITHDRAW: ResultPrefix = [
     246, 181, 82, 1, 204, 142, 13, 135, 141, 218, 111, 185, 98, 41, 84, 186, 141, 37, 252, 127, 56,
     255, 227, 34, 202, 249, 14, 225, 115, 248, 131, 171,
 ];
+
+/// This prefix value is computed as: `keccak256(b"ResultType.Lock").as_slice()`
 pub const RESULT_PREFIX_LOCK: ResultPrefix = [
     10, 158, 184, 119, 69, 133, 121, 219, 206, 131, 234, 87, 213, 86, 190, 80, 209, 195, 22, 11,
     181, 241, 113, 159, 177, 114, 189, 51, 0, 172, 134, 35,
 ];
+
+/// This prefix value is computed as: `keccak256(b"ResultType.Metadata").as_slice()`
 pub const RESULT_PREFIX_METADATA: ResultPrefix = [
     179, 21, 212, 214, 232, 242, 53, 245, 250, 187, 11, 26, 15, 17, 133, 7, 246, 200, 84, 47, 174,
     142, 26, 149, 102, 171, 230, 7, 98, 4, 124, 22,

--- a/bridge-common/src/result_types.rs
+++ b/bridge-common/src/result_types.rs
@@ -31,14 +31,14 @@ pub struct Withdraw {
     pub recipient: EthAddress,
 }
 
-impl Default for Withdraw {
-    fn default() -> Self {
+impl Withdraw {
+    pub fn new(amount: Balance, token: EthAddress, recipient: EthAddress) -> Self {
         Self {
             #[cfg(feature = "result_with_prefix")]
             prefix: RESULT_PREFIX_WITHDRAW,
-            amount: Default::default(),
-            token: Default::default(),
-            recipient: Default::default(),
+            amount,
+            token,
+            recipient,
         }
     }
 }
@@ -52,14 +52,14 @@ pub struct Lock {
     pub recipient: EthAddress,
 }
 
-impl Default for Lock {
-    fn default() -> Self {
+impl Lock {
+    pub fn new(token: String, amount: Balance, recipient: EthAddress) -> Self {
         Self {
             #[cfg(feature = "result_with_prefix")]
             prefix: RESULT_PREFIX_LOCK,
-            token: Default::default(),
-            amount: Default::default(),
-            recipient: Default::default(),
+            token,
+            amount,
+            recipient,
         }
     }
 }
@@ -75,16 +75,22 @@ pub struct Metadata {
     pub block_height: BlockHeight,
 }
 
-impl Default for Metadata {
-    fn default() -> Self {
+impl Metadata {
+    pub fn new(
+        token: String,
+        name: String,
+        symbol: String,
+        decimals: u8,
+        block_height: BlockHeight,
+    ) -> Self {
         Self {
             #[cfg(feature = "result_with_prefix")]
             prefix: RESULT_PREFIX_METADATA,
-            token: Default::default(),
-            name: Default::default(),
-            symbol: Default::default(),
-            decimals: Default::default(),
-            block_height: Default::default(),
+            token,
+            name,
+            symbol,
+            decimals,
+            block_height,
         }
     }
 }
@@ -104,13 +110,16 @@ fn generate_result_prefixs() {
         near_sdk::env::keccak256(b"ResultType.Metadata").as_slice()
     );
 
-    println!(
-        "RESULT_PREFIX_WITHDRAW: {}",
+    assert_eq!(
+        "f6b55201cc8e0d878dda6fb9622954ba8d25fc7f38ffe322caf90ee173f883ab",
         hex::encode(RESULT_PREFIX_WITHDRAW)
     );
-    println!("RESULT_PREFIX_LOCK: {}", hex::encode(RESULT_PREFIX_LOCK));
-    println!(
-        "RESULT_PREFIX_METADATA: {}",
+    assert_eq!(
+        "0a9eb877458579dbce83ea57d556be50d1c3160bb5f1719fb172bd3300ac8623",
+        hex::encode(RESULT_PREFIX_LOCK)
+    );
+    assert_eq!(
+        "b315d4d6e8f235f5fabb0b1a0f118507f6c8542fae8e1a9566abe60762047c16",
         hex::encode(RESULT_PREFIX_METADATA)
     );
 }

--- a/bridge-token-factory/Cargo.toml
+++ b/bridge-token-factory/Cargo.toml
@@ -23,7 +23,7 @@ near-contract-standards = "4.0.0"
 eth-types =  { git = "https://github.com/near/rainbow-bridge", rev = "8644d02031250470556b07fdf3506f13357eb8b7" }
 admin-controlled = { git = "https://github.com/near/rainbow-bridge", rev = "8644d02031250470556b07fdf3506f13357eb8b7" }
 ethabi = "12.0.0"
-bridge-common = { path = "../bridge-common" }
+bridge-common = { path = "../bridge-common", default-features = false }
 hex = "0.4.2"
 bridge-token = { path = "../bridge-token" }
 

--- a/bridge-token-factory/src/lib.rs
+++ b/bridge-token-factory/src/lib.rs
@@ -8,9 +8,8 @@ use near_sdk::{
     env, ext_contract, near_bindgen, AccountId, Balance, Gas, PanicOnDefault, Promise, PublicKey,
 };
 
-use bridge_common::prover::*;
 pub use bridge_common::prover::{validate_eth_address, Proof};
-use bridge_common::{parse_recipient, Recipient, ResultType};
+use bridge_common::{parse_recipient, prover::*, result_types, Recipient};
 pub use lock_event::EthLockedEvent;
 pub use log_metadata_event::TokenMetadataEvent;
 use near_sdk_inner::PromiseOrValue;
@@ -368,7 +367,7 @@ impl BridgeTokenFactory {
         &mut self,
         #[serializer(borsh)] amount: Balance,
         #[serializer(borsh)] recipient: String,
-    ) -> ResultType {
+    ) -> result_types::Withdraw {
         let token = env::predecessor_account_id();
         let parts: Vec<&str> = token.as_str().split(".").collect();
         assert_eq!(
@@ -382,10 +381,11 @@ impl BridgeTokenFactory {
         );
         let token_address = validate_eth_address(parts[0].to_string());
         let recipient_address = validate_eth_address(recipient);
-        ResultType::Withdraw {
+        result_types::Withdraw {
             amount: amount.into(),
             token: token_address,
             recipient: recipient_address,
+            ..Default::default()
         }
     }
 
@@ -701,10 +701,11 @@ mod tests {
         let address = validate_eth_address(token_locker());
         assert_eq!(
             contract.finish_withdraw(1_000, token_locker()),
-            ResultType::Withdraw {
+            result_types::Withdraw {
                 amount: 1_000,
                 token: address,
-                recipient: address
+                recipient: address,
+                ..Default::default()
             }
         );
     }

--- a/bridge-token-factory/src/lib.rs
+++ b/bridge-token-factory/src/lib.rs
@@ -381,12 +381,7 @@ impl BridgeTokenFactory {
         );
         let token_address = validate_eth_address(parts[0].to_string());
         let recipient_address = validate_eth_address(recipient);
-        result_types::Withdraw {
-            amount: amount.into(),
-            token: token_address,
-            recipient: recipient_address,
-            ..Default::default()
-        }
+        result_types::Withdraw::new(amount, token_address, recipient_address)
     }
 
     #[payable]
@@ -701,12 +696,7 @@ mod tests {
         let address = validate_eth_address(token_locker());
         assert_eq!(
             contract.finish_withdraw(1_000, token_locker()),
-            result_types::Withdraw {
-                amount: 1_000,
-                token: address,
-                recipient: address,
-                ..Default::default()
-            }
+            result_types::Withdraw::new(1_000, address, address)
         );
     }
 

--- a/erc20-bridge-token/contracts/ResultsDecoder.sol
+++ b/erc20-bridge-token/contracts/ResultsDecoder.sol
@@ -3,8 +3,10 @@ import "rainbow-bridge-sol/nearbridge/contracts/Borsh.sol";
 
 library ResultsDecoder {
     using Borsh for Borsh.Data;
+    bytes32 public constant RESULT_PREFIX_LOCK = 0x0a9eb877458579dbce83ea57d556be50d1c3160bb5f1719fb172bd3300ac8623;
+    bytes32 public constant RESULT_PREFIX_METADATA = 0xb315d4d6e8f235f5fabb0b1a0f118507f6c8542fae8e1a9566abe60762047c16;
 
-   struct LockResult {
+    struct LockResult {
         string token;
         uint128 amount;
         address recipient;
@@ -19,6 +21,8 @@ library ResultsDecoder {
 
     function decodeLockResult(bytes memory data) external pure returns(LockResult memory result) {
         Borsh.Data memory borshData = Borsh.from(data);
+        bytes32 prefix = borshData.decodeBytes32();
+        require(prefix == RESULT_PREFIX_LOCK, "ERR_INVALID_LOCK_PREFIX");
         result.token = string(borshData.decodeBytes());
         result.amount = borshData.decodeU128();
         bytes20 recipient = borshData.decodeBytes20();
@@ -27,6 +31,8 @@ library ResultsDecoder {
     }
        function decodeMetadataResult(bytes memory data) external pure returns(MetadataResult memory result) {
         Borsh.Data memory borshData = Borsh.from(data);
+        bytes32 prefix = borshData.decodeBytes32();
+        require(prefix == RESULT_PREFIX_METADATA, "ERR_INVALID_METADATA_PREFIX");
         result.token = string(borshData.decodeBytes());
         result.name = string(borshData.decodeBytes());
         result.symbol = string(borshData.decodeBytes());

--- a/token-locker/src/lib.rs
+++ b/token-locker/src/lib.rs
@@ -158,7 +158,7 @@ impl Contract {
             metadata.name,
             metadata.symbol,
             metadata.decimals,
-            env::block_height()
+            env::block_height(),
         )
     }
 
@@ -236,13 +236,13 @@ impl Contract {
 
         match message {
             Some(message) => ext_token::ext(token.try_into().unwrap())
-                .with_attached_deposit(1)
+                .with_attached_deposit(near_sdk::ONE_YOCTO)
                 .with_static_gas(FT_TRANSFER_CALL_GAS)
-                .ft_transfer_call(target.try_into().unwrap(), amount.into(), None, message),
+                .ft_transfer_call(target, amount.into(), None, message),
             None => ext_token::ext(token.try_into().unwrap())
-                .with_attached_deposit(1)
+                .with_attached_deposit(near_sdk::ONE_YOCTO)
                 .with_static_gas(FT_TRANSFER_GAS)
-                .ft_transfer(target.into(), amount.into(), None),
+                .ft_transfer(target, amount.into(), None),
         }
     }
 


### PR DESCRIPTION
A prefix was added to results structures to avoid collisions on decoding the proof