### PR TITLE
ERC20 connector: lock pragma to Solidity v0.8.11

### DIFF
--- a/erc20-connector/contracts/ERC20Locker.sol
+++ b/erc20-connector/contracts/ERC20Locker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8;
+pragma solidity ^0.8.11;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";


### PR DESCRIPTION
Previously, we used to have `pragma solidity ^0.8.11` definition for `ERC20Locker` and `Locker` contracts. Even though the contract is being compiled via the Hardhat interface and the specific compiler version is defined in `hardhat.config.js`, it makes sense to add an extra precaution in the code to avoid deploying with the latest compiler by mistake.